### PR TITLE
add options passthrough to removeOAuthIdentity

### DIFF
--- a/src/core/sift-view.js
+++ b/src/core/sift-view.js
@@ -118,9 +118,9 @@ export default class SiftView {
     this.notifyClient(topic, value);
   }
 
-  removeOAuthIdentity({ provider }) {
+  removeOAuthIdentity({ provider, options = null  }) {
     const topic = 'showOAuthRemovePopup';
-    const value = { provider };
+    const value = { provider, options };
 
     this.notifyClient(topic, value);
   }


### PR DESCRIPTION
- add options passthrough to removeOAuthIdentity, like showOAuthPopup. This is required for the redirect option to be passed through to `cloud`.